### PR TITLE
Add `-location` utility target to generate the location of a target's artifacts

### DIFF
--- a/fs_image/bzl/defs.bzl
+++ b/fs_image/bzl/defs.bzl
@@ -1,4 +1,5 @@
 load(":oss_shim.bzl", "buck_genrule", "get_visibility")
+load(":target_tagger.bzl", "wrap_target")
 
 def fake_macro_library(name, srcs, deps = None, visibility = None):
     """
@@ -36,3 +37,24 @@ def fake_macro_library(name, srcs, deps = None, visibility = None):
         type = "fake_macro_library",
         visibility = get_visibility(visibility, name),
     )
+
+def target_location(target):
+    """
+    This rule generates a file that contains a string that is the location of
+    the artifact produced by the requested target.  This rule's contents can
+    then be used by the `fs_image.common.load_location` python helper in
+    combination with a `resource` to read the location of the target.
+    """
+    exists, wrapped_target = wrap_target(target, "wrapped_target_location")
+
+    if not exists:
+        buck_genrule(
+            name = wrapped_target,
+            out = "location",
+            bash = 'echo "$(location {})" > "$OUT"'.format(target),
+            cacheable = False,
+            type = "wrapped_target_location",
+            visibility = [],
+        )
+
+    return ":" + wrapped_target

--- a/fs_image/bzl/target_tagger.bzl
+++ b/fs_image/bzl/target_tagger.bzl
@@ -56,7 +56,7 @@ def tag_required_target_key(tagger, d, target_key, is_layer = False):
         )
     d[target_key] = tag_target(tagger, target = d[target_key], is_layer = is_layer)
 
-def tag_and_maybe_wrap_executable_target(target_tagger, target, wrap_prefix, **kwargs):
+def wrap_target(target, wrap_prefix):
     # The target to wrap may be in a different directory, so we normalize
     # its path to ensure the hashing is deterministic.  This assures reuse
     # at least within the current TARGETS files.
@@ -72,7 +72,12 @@ def tag_and_maybe_wrap_executable_target(target_tagger, target, wrap_prefix, **k
         name if len(name) < 15 else (name[:6] + "..." + name[-6:])
     ) + "__" + hex_crc32(target)
 
-    if native.rule_exists(wrapped_target):
+    return native.rule_exists(wrapped_target), wrapped_target
+
+def tag_and_maybe_wrap_executable_target(target_tagger, target, wrap_prefix, **kwargs):
+    exists, wrapped_target = wrap_target(target, wrap_prefix)
+
+    if exists:
         return True, tag_target(target_tagger, ":" + wrapped_target)
 
     # The `wrap_runtime_deps_as_build_time_deps` docblock explains this:

--- a/fs_image/common.py
+++ b/fs_image/common.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 'Utilities to make Python systems programming more palatable.'
 import array
+import importlib.resources
 import logging
 import os
 import random
@@ -29,6 +30,14 @@ def init_logging(*, debug: bool=False):
         format='%(levelname)s %(name)s %(asctime)s %(message)s',
         level=logging.DEBUG if debug else logging.INFO,
     )
+
+
+def load_location(package: AnyStr, name: AnyStr) -> str:
+    '''Load and prepare a target location bundled into a python target
+    as a resource. See the docblock of fs_image/bzl/defs.bzl:target_location
+    for more details on what a target location is all about.'''
+
+    return importlib.resources.read_text(package, name).strip()
 
 
 # contextlib.nullcontext is 3.7+ but we are on 3.6 for now. This has to be a

--- a/fs_image/rpm/BUCK
+++ b/fs_image/rpm/BUCK
@@ -1,3 +1,4 @@
+load("//fs_image/bzl:defs.bzl", "target_location")
 load("//fs_image/bzl:oss_shim.bzl", "buck_genrule", "platform_utils", "python_binary", "python_library", "python_unittest", "third_party")
 
 python_library(
@@ -70,10 +71,12 @@ python_library(
     srcs = ["tests/temp_repos.py"],
     base_module = "rpm",
     resources = {
-        third_party.replace_third_party_repo(
-            "third-party//busybox:bin/busybox",
-            platform_utils.get_platform_for_current_buildfile(),
-        ): "tests/third_party/busybox",
+        target_location(
+            third_party.replace_third_party_repo(
+                "third-party//busybox:bin/busybox",
+                platform_utils.get_platform_for_current_buildfile(),
+            ),
+        ): "busybox-path",
         # NB: It would be great to also use `rpmbuild` from the third-party
         # repo, but doing this is fairly intractable, see D15511231.
     },
@@ -373,7 +376,9 @@ python_binary(
     main_module = "rpm.tests.yum_from_test_snapshot",
     # Needed for `repo_server` & `repo_snapshot` to be visible in @mode/opt
     par_style = "xar",
-    resources = {":repo_snapshot_dir_for_tests": "tests/repo_snapshot"},
+    resources = {
+        target_location(":repo_snapshot_dir_for_tests"): "repo-snapshot",
+    },
     deps = [":yum-from-snapshot-library"],
 )
 

--- a/fs_image/rpm/tests/temp_repos.py
+++ b/fs_image/rpm/tests/temp_repos.py
@@ -12,10 +12,7 @@ from contextlib import contextmanager
 from typing import Dict, List, NamedTuple, Optional
 
 from ..common import Path, temp_dir
-
-
-def busybox_path() -> str:
-    return os.path.join(os.path.dirname(__file__), 'third_party/busybox')
+from fs_image.common import load_location
 
 
 def rpmbuild_path() -> str:
@@ -41,7 +38,9 @@ class Rpm(NamedTuple):
                     if self.override_contents is None
                     else self.override_contents
             ),
-            'quoted_busybox_path': shlex.quote(busybox_path()),
+            'quoted_busybox_path': shlex.quote(
+                load_location('rpm', 'busybox-path')
+            )
         }
 
         common_spec = textwrap.dedent('''\

--- a/fs_image/rpm/tests/yum_from_test_snapshot.py
+++ b/fs_image/rpm/tests/yum_from_test_snapshot.py
@@ -10,6 +10,7 @@ from typing import AnyStr, List
 
 from ..common import init_logging, Path
 from ..yum_from_snapshot import add_common_yum_args, yum_from_snapshot
+from fs_image.common import load_location
 
 
 def yum_from_test_snapshot(
@@ -17,7 +18,7 @@ def yum_from_test_snapshot(
     protected_paths: List[AnyStr],
     yum_args: List[AnyStr],
 ):
-    snapshot_dir = Path(__file__).dirname() / 'repo_snapshot'  # via `resources`
+    snapshot_dir = Path(load_location('rpm', 'repo-snapshot'))
     yum_from_snapshot(
         storage_cfg=json.dumps({
             'key': 'test',


### PR DESCRIPTION
Summary:
Add `-location` utility target to generate the location of a target's
artifacts.  The utility for this is to provide a mechanism for `python_*`
targets to discover the location of dependent artifacts in the `buck-out/`
path.  This mechanism is intended to be used instead of the current `__file__`
based method of discovering bundled resources to support OSS builds.  In OSS
the python packaging is done via `pex` and by default `pex` files are marked as
`zip-safe` which means that the native python import logic can import resources
directly from the `pex` zip file without unpacking.

Note that we *can* force `not-zip-safe` `pex` files, which means that they get
unpacked onto disk in all cases, but my preference would be that we not require
that behavior.  This mechanism provides an working alternative to forcing a
specific runtime behavior.

Note also that this works well for binaries/unittest that only run in the context of
a buck working directory, ie: unittests.  This won't be that useful for binaries
that are assumed to be bundled together such as `yum-from-snapshot`, which
embeds `repo-server` inside of it.

Differential Revision: D18783471

