### PR TITLE
Pure python implementation of rpm version comparison

### DIFF
--- a/fs_image/rpm/BUCK
+++ b/fs_image/rpm/BUCK
@@ -475,11 +475,6 @@ python_library(
         ":common",
         "//fs_image:subvol_utils",
     ],
-    external_deps = [
-        third_party.library(
-            ("rpm", None, "python-rpm"),
-        ),
-    ],
 )
 
 python_unittest(

--- a/fs_image/rpm/rpm_metadata.py
+++ b/fs_image/rpm/rpm_metadata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-import rpm
+import re
 import subprocess
 
 from .common import Path, get_file_logger
@@ -70,19 +70,135 @@ class RpmMetadata(NamedTuple):
         return RpmMetadata(name=n, epoch=int(e), version=v, release=r)
 
 
-# Returns  1 if the version of a is newer than b
-# Returns  0 if the versions match
-# Returns -1 if the version of a is older than b
+# This comprises a pure python implementation of rpm version comparison. The
+# purpose for this is so that the fs_image library does not have a dependency
+# on a C library that is (for the most part) only distributed as part of rpm
+# based distros. Depending on a C library complicates dependency management
+# significantly in the OSS space due to the complexity of handling 3rd party C
+# libraries with buck. Having this pure python implementation also eases future
+# rpm usage/handling for both non-rpm based distros and different arch types.
 #
-# Referenced from:
-# github.com/rpm-software-management/yum/blob/master/rpmUtils/miscutils.py
+# This implementation is adapted from both this blog post:
+#  https://blog.jasonantman.com/2014/07/how-yum-and-rpm-compare-versions/
+# and this Apache 2 licenses implementation:
+#   https://github.com/sassoftware/python-rpm-vercmp/blob/master/rpm_vercmp/vercmp.py
+#
+# There are extensive test cases in the `test_rpm_metadata.py` test case that
+# cover a wide variety of normal and weird version comparsions.
 def compare_rpm_versions(a: RpmMetadata, b: RpmMetadata) -> int:
+    """
+        Returns:
+            1 if the version of a is newer than b
+            0 if the versions match
+            -1 if the version of a is older than b
+    """
+
     # This is not a rule, but it makes sense that our libs don't want to
     # compare versions of different RPMs
     if a.name != b.name:
         raise ValueError(f"Cannot compare RPM versions when names do not match")
 
-    return rpm.labelCompare(
-        (str(a.epoch), a.version, a.release),
-        (str(b.epoch), b.version, b.release)
-    )
+    # First compare the epoch, if set.  If the epoch's are not the same, then
+    # the higher one wins no matter what the rest of the EVR is.
+    if a.epoch != b.epoch:
+        if a.epoch > b.epoch:
+            return 1  # a > b
+        else:
+            return -1  # a < b
+
+    # Epoch is the same, if version + release are the same we have a match
+    if (a.version == b.version) and (a.release == b.release):
+        return 0  # a == b
+
+    # Compare version first, if version is equal then compare release
+    compare_res = _compare_values(a.version, b.version)
+    if compare_res != 0:  # a > b || a < b
+        return compare_res
+    else:
+        return _compare_values(a.release, b.release)
+
+
+R_NON_ALPHA_NUM_TILDE = re.compile(r"^([^a-zA-Z0-9~]*)(.*)$")
+R_NUM = re.compile(r"^([\d]+)(.*)$")
+R_ALPHA = re.compile(r"^([a-zA-Z]+)(.*)$")
+
+
+def _compare_values(a: str, b: str) -> int:
+    if a == b:
+        return 0
+
+    while a or b:
+        match_a = R_NON_ALPHA_NUM_TILDE.match(a)
+        match_b = R_NON_ALPHA_NUM_TILDE.match(b)
+        a_head, a = match_a.group(1), match_a.group(2)
+        b_head, b = match_b.group(1), match_b.group(2)
+
+        # Ignore anything at the start we don't want
+        if a_head or b_head:
+            continue
+
+        # Look at tilde first, it takes precedent over everything else
+        if a.startswith('~'):
+            if not b.startswith('~'):
+                return -1  # a < b
+
+            # Strip the tilde and start again
+            a, b = a[1:], b[1:]
+            continue
+
+        if b.startswith('~'):
+            return 1  # a > b
+
+        # We've run out of characters to compare.
+        # Note: we have to do this after we compare the ~ madness because
+        # ~'s take precedance.
+        if not a or not b:
+            break
+
+        # Lets see if the values are numbers
+        match_a = R_NUM.match(a)
+        if match_a:
+            match_b = R_NUM.match(b)
+            if not match_b:  # b is not a num and nums > alphas
+                return 1  # a > b
+            isnum = True
+        else:
+            match_a = R_ALPHA.match(a)
+            match_b = R_ALPHA.match(b)
+            isnum = False
+
+        # strip off the leading numeric or alpha chars
+        a_head, a = match_a.group(1), match_a.group(2)
+        b_head, b = match_b.group(1), match_b.group(2)
+
+        if isnum:
+            a_head = a_head.lstrip('0')
+            b_head = b_head.lstrip('0')
+
+            # Length of contiguous numbers matters
+            a_head_len = len(a_head)
+            b_head_len = len(b_head)
+            if a_head_len < b_head_len:
+                return -1  # a < b
+            if a_head_len > b_head_len:
+                return 1  # a > b
+
+        # Either a number with the same number of chars or
+        # the leading chars are alpha so lets do a standard compare
+        if a_head < b_head:
+            return -1  # a < b
+        if a_head > b_head:
+            return 1  # a > b
+
+        # Both header segments are of equal length, keep going with the new
+        continue  # pragma: no cover
+
+    # Both are now zero length, that means they must be equal
+    if len(a) == len(b) == 0:
+        return 0  # a == b
+
+    # Longer string is > than shorter string
+    if len(a) != 0:
+        return 1  # a > b
+
+    return -1  # a < b

--- a/fs_image/rpm/tests/test_rpm_metadata.py
+++ b/fs_image/rpm/tests/test_rpm_metadata.py
@@ -85,7 +85,10 @@ class RpmMetadataTestCase(unittest.TestCase):
             ((0, '^1', '3'), (0, '^', '3'), 1),        # 0:^1-3 > 0:^-3
             ((0, '^', '3'), (0, '^1', '3'), -1),       # 0:^-3 < 0:^1-3
             ((0, '0333', 'b'), (0, '0033', 'b'), 1),   # 0:0333-b > 0:0033-b
+            ((0, '0033', 'b'), (0, '0333', 'b'), -1),  # 0:0033-b < 0:0333-b
             ((0, '3', '~~'), (0, '3', '~~~'), 1),      # 0:3-~~ > 0:3-~~~
+            ((0, '3', '~~~'), (0, '3', '~~'), -1),     # 0:3-~~~ < 0:3-~~
+            ((0, '3', '~~~'), (0, '3', '~~~'), 0),     # 0:3-~~~ == 0:3-~~~
             ((0, 'a2aa', 'b'), (0, 'a2a', 'b'), 1),    # 0:a2aa-b > 0:a2a-b
             ((0, '33', 'b'), (0, 'aaa', 'b'), 1),      # 0:33-b > 0:aaa-b
         ]
@@ -93,4 +96,5 @@ class RpmMetadataTestCase(unittest.TestCase):
         for evr1, evr2, expected in test_data:
             a = RpmMetadata('test-name', *evr1)
             b = RpmMetadata('test-name', *evr2)
-            self.assertEqual(compare_rpm_versions(a, b), expected)
+            self.assertEqual(compare_rpm_versions(a, b),
+                    expected, f'failed: {evr1}, {evr2}, {expected}')


### PR DESCRIPTION
Summary: This provides a pure python implemenation for comparing rpm versions.  The primary purpose of this is to remove the external, third-party dependency on the `python-rpm` module that requires/relies on compiled shared objects. More description about this is in the comments.

Differential Revision: D19519858

