### PR TITLE
Re-sync with internal repository

### DIFF
--- a/fs_image/bzl/oss_shim.bzl
+++ b/fs_image/bzl/oss_shim.bzl
@@ -86,6 +86,7 @@ def python_unittest(*args, **kwargs):
 buck_command_alias = shim.buck_command_alias
 buck_genrule = shim.buck_genrule
 buck_sh_binary = shim.buck_sh_binary
+buck_sh_test = shim.buck_sh_test
 config = shim.config
 get_visibility = shim.get_visibility
 target_utils = shim.target_utils

--- a/fs_image/bzl/oss_shim_impl.bzl
+++ b/fs_image/bzl/oss_shim_impl.bzl
@@ -34,7 +34,7 @@ def _normalize_visibility(vis, name=None):
 
 def _normalize_pkg_style(style):
     """
-    Internally, zip and fastzip internally behave similar to how an 
+    Internally, zip and fastzip internally behave similar to how an
     `inplace` python binary behaves in OSS Buck.
     """
     if style and style in ('zip', 'fastzip'):


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.