### PR TITLE
Re-sync with internal repository

### DIFF
--- a/fs_image/bzl/oss_shim.bzl
+++ b/fs_image/bzl/oss_shim.bzl
@@ -1,4 +1,4 @@
-# Thi file redeclares (and potentially validates) JUST the part of the
+# This file redeclares (and potentially validates) JUST the part of the
 # fbcode macro API that is allowed within `fs_image/`.  This way,
 # FB-internal contributors will be less likely to accidentally break
 # open-source by starting to use un-shimmed features.

--- a/fs_image/bzl/oss_shim_vm.bzl
+++ b/fs_image/bzl/oss_shim_vm.bzl
@@ -1,3 +1,4 @@
-load(":oss_shim_vm_impl.bzl", _image_vm_cpp_unittest = "image_vm_cpp_unittest")
+load(":oss_shim_vm_impl.bzl", _image_vm_cpp_unittest = "image_vm_cpp_unittest", _image_vm_python_unittest = "image_vm_python_unittest")
 
 image_vm_cpp_unittest = _image_vm_cpp_unittest
+image_vm_python_unittest = _image_vm_python_unittest

--- a/fs_image/bzl/oss_shim_vm_impl.bzl
+++ b/fs_image/bzl/oss_shim_vm_impl.bzl
@@ -1,1 +1,2 @@
 image_vm_cpp_unittest = None
+image_vm_python_unittest = None

--- a/fs_image/bzl/tests/BUCK
+++ b/fs_image/bzl/tests/BUCK
@@ -155,7 +155,7 @@ image.layer(
 )
 
 cpp_container_and_vm_test(
-    name = "test-cpp-runs-in-layer"
+    name = "test-cpp-runs-in-layer",
     srcs = ["RunsInLayerTest.cpp"],
     layer = ":layer-with-unique-path",
     deps = ["//common/files:files"],

--- a/fs_image/bzl/tests/container_and_vm_test.bzl
+++ b/fs_image/bzl/tests/container_and_vm_test.bzl
@@ -1,5 +1,5 @@
 load("//fs_image/bzl:image.bzl", "image")
-load("//fs_image/bzl:oss_shim_vm.bzl", "image_vm_cpp_unittest")
+load("//fs_image/bzl:oss_shim_vm.bzl", "image_vm_cpp_unittest", "image_vm_python_unittest")
 
 def cpp_container_and_vm_test(
         name,
@@ -17,7 +17,7 @@ def cpp_container_and_vm_test(
     # image_vm_cpp_unittest is not yet available in OSS
     if image_vm_cpp_unittest:
         image_vm_cpp_unittest(
-            name = name  "-in-vm",
+            name = name + "-in-vm",
             layer = layer,
             kernel_opts = kernel_opts,
             visibility = visibility,

--- a/fs_image/bzl/tests/test_runs_in_layer.py
+++ b/fs_image/bzl/tests/test_runs_in_layer.py
@@ -6,7 +6,7 @@ from coverage_test_helper import coverage_test_helper
 
 
 class RunsInLayerTest(unittest.TestCase):
-    
+
     def test_unique_path_exists(self):
         # This should cause our 100% coverage assertion to pass.
         coverage_test_helper()


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.