### PR TITLE
Fedora 31 Kernel RPMs

### DIFF
--- a/fs_image/bzl/oss_shim_impl.bzl
+++ b/fs_image/bzl/oss_shim_impl.bzl
@@ -29,7 +29,17 @@ def _invert_dict(d):
 
 def _kernel_artifact_version(version):
     """ Resolve a kernel version to its corresponding kernel artifact.
-    Internally, the kernel artifacts are in `//kernel/kernels:kernel.bzl`
+    Currently, the only `kernel_artifact` available is in
+    //third-party/fedora31/kernel:kernels.bzl.
+
+    a `kernel_artifact`is a struct containing the following members:
+    - uname
+    - vmlinuz: compressed vmlinux
+    - modules: kernel modules
+    - headers: Includes the C header files that specify the interface between the
+               Linux kernel and user-space libraries and programs.
+    - devel:   Contains the kernel headers and makefiles sufficient to build modules
+               against the kernel package.
     """
     if version in kernels:
         return kernels[version]

--- a/fs_image/bzl/oss_shim_impl.bzl
+++ b/fs_image/bzl/oss_shim_impl.bzl
@@ -1,4 +1,5 @@
 load("@bazel_skylib//lib:types.bzl", "types")
+load("//third-party/fedora31/kernel:kernels.bzl", "kernels")
 
 # The default native platform to use for shared libraries and static binary
 # dependencies.  Right now this tooling only supports one platform and so
@@ -25,6 +26,15 @@ def _invert_dict(d):
         return result
     else:
         return d
+
+def _kernel_artifact_version(version):
+    """ Resolve a kernel version to its corresponding kernel artifact.
+    Internally, the kernel artifacts are in `//kernel/kernels:kernel.bzl`
+    """
+    if version in kernels:
+        return kernels[version]
+    else:
+        fail("Unknown kernel version: {}".format(version))
 
 def _normalize_deps(deps, more_deps = None):
     """  Create a single list of deps from one or 2 provided lists of deps.
@@ -202,6 +212,10 @@ shim = struct(
         get_project_root_from_gen_dir = _get_project_root_from_gen_dir,
     ),
     get_visibility = _normalize_visibility,
+    kernel_artifact = struct(
+        default_kernel = _kernel_artifact_version("5.3.7-301.fc31.x86_64"),
+        version = _kernel_artifact_version,
+    ),
     platform_utils = None,
     python_binary = _python_binary,
     python_library = _python_library,

--- a/third-party/fedora31/kernel/BUCK
+++ b/third-party/fedora31/kernel/BUCK
@@ -25,8 +25,8 @@ genrule(
     cmd = """
         cd $OUT
         rpm2cpio $(location :5.3.7-301.fc31.x86_64-core.rpm) | cpio -idm
-        rm -r lib/modules/5.3.7-301.fc31.x86_64/build
-        rm -r lib/modules/5.3.7-301.fc31.x86_64/source
+        # Removing build and source since they are symlinks that do not exist on the host
+        rm -r lib/modules/5.3.7-301.fc31.x86_64/build lib/modules/5.3.7-301.fc31.x86_64/source
     """
 )
 

--- a/third-party/fedora31/kernel/BUCK
+++ b/third-party/fedora31/kernel/BUCK
@@ -1,0 +1,47 @@
+remote_file(
+    name = "kernel-core-5.3.7-301.fc31.x86_64.rpm",
+    url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-core-5.3.7-301.fc31.x86_64.rpm",
+    sha1 = "dae4263b23930c4f25a7eae28a1fda606abfd561",
+    out = "kernel-core-5.3.7-301.fc31.x86_64.rpm",
+)
+
+remote_file(
+    name = "kernel-headers-5.3.6-300.fc31.x86_64.rpm",
+    url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-headers-5.3.6-300.fc31.x86_64.rpm",
+    sha1 = "7fe40f1592bb8ac3c47d3f97b447a7bf6f2e0a05",
+    out = "kernel-headers-5.3.6-300.fc31.x86_64.rpm",
+)
+
+remote_file(
+    name = "kernel-devel-5.3.7-301.fc31.x86_64.rpm", 
+    url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-devel-5.3.7-301.fc31.x86_64.rpm",
+    sha1 = "ff5bebf0be74228591bc046175815a3e5ce927f2",
+    out = "kernel-devel-5.3.7-301.fc31.x86_64.rpm",
+)
+
+genrule(
+    name = "5.3.7-301.fc31.x86_64-rpm-exploded",
+    out = ".",
+    cmd = """
+        cd $OUT
+        rpm2cpio $(location :kernel-core-5.3.7-301.fc31.x86_64.rpm) | cpio -idm
+    """
+)
+
+genrule(
+    name = "5.3.7-301.fc31.x86_64-vmlinuz",
+    out = "vmlinuz-5.3.7-301.fc31.x86_64",
+    cmd = "cp --reflink=auto $(location :5.3.7-301.fc31.x86_64-rpm-exploded)/lib/modules/5.3.7-301.fc31.x86_64/vmlinuz $OUT",
+)
+
+# this is all the modules that the kernel could possibly need. they are
+# copied into the initrd so that they don't have to be installed in the
+# root disk
+genrule(
+    name = "5.3.7-301.fc31.x86_64-modules",
+    out = ".",
+    cmd = """
+        mkdir -p $OUT
+        cp -R "$(location :5.3.7-301.fc31.x86_64-rpm-exploded)/lib/modules/5.3.7-301.fc31.x86_64/kernel" "$OUT"
+    """
+)

--- a/third-party/fedora31/kernel/BUCK
+++ b/third-party/fedora31/kernel/BUCK
@@ -1,22 +1,22 @@
 remote_file(
-    name = "kernel-core-5.3.7-301.fc31.x86_64.rpm",
+    name = "5.3.7-301.fc31.x86_64-core.rpm",
     url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-core-5.3.7-301.fc31.x86_64.rpm",
     sha1 = "dae4263b23930c4f25a7eae28a1fda606abfd561",
-    out = "kernel-core-5.3.7-301.fc31.x86_64.rpm",
+    out = "5.3.7-301.fc31.x86_64-core.rpm",
 )
 
 remote_file(
-    name = "kernel-headers-5.3.6-300.fc31.x86_64.rpm",
+    name = "5.3.6-300.fc31.x86_64-headers.rpm",
     url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-headers-5.3.6-300.fc31.x86_64.rpm",
     sha1 = "7fe40f1592bb8ac3c47d3f97b447a7bf6f2e0a05",
-    out = "kernel-headers-5.3.6-300.fc31.x86_64.rpm",
+    out = "5.3.6-300.fc31.x86_64-headers.rpm",
 )
 
 remote_file(
-    name = "kernel-devel-5.3.7-301.fc31.x86_64.rpm", 
+    name = "5.3.7-301.fc31.x86_64-devel.rpm",
     url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-devel-5.3.7-301.fc31.x86_64.rpm",
     sha1 = "ff5bebf0be74228591bc046175815a3e5ce927f2",
-    out = "kernel-devel-5.3.7-301.fc31.x86_64.rpm",
+    out = "5.3.7-301.fc31.x86_64-devel.rpm",
 )
 
 genrule(
@@ -24,7 +24,7 @@ genrule(
     out = ".",
     cmd = """
         cd $OUT
-        rpm2cpio $(location :kernel-core-5.3.7-301.fc31.x86_64.rpm) | cpio -idm
+        rpm2cpio $(location :5.3.7-301.fc31.x86_64-core.rpm) | cpio -idm
         rm -r lib/modules/5.3.7-301.fc31.x86_64/build
         rm -r lib/modules/5.3.7-301.fc31.x86_64/source
     """

--- a/third-party/fedora31/kernel/BUCK
+++ b/third-party/fedora31/kernel/BUCK
@@ -25,6 +25,8 @@ genrule(
     cmd = """
         cd $OUT
         rpm2cpio $(location :kernel-core-5.3.7-301.fc31.x86_64.rpm) | cpio -idm
+        rm -r lib/modules/5.3.7-301.fc31.x86_64/build
+        rm -r lib/modules/5.3.7-301.fc31.x86_64/source
     """
 )
 

--- a/third-party/fedora31/kernel/kernels.bzl
+++ b/third-party/fedora31/kernel/kernels.bzl
@@ -1,0 +1,9 @@
+kernels = {
+    "5.3.7-301.fc31.x86_64": struct(
+        uname = "5.3.7-301.fc31.x86_64",
+        vmlinuz = "//third-party/fedora31/kernel:5.3.7-301.fc31.x86_64-vmlinuz",
+        modules = "//third-party/fedora31/kernel:5.3.7-301.fc31.x86_64-modules",
+        headers = "//third-party/fedora31/kernel:5.3.6-300.fc31.x86_64-headers.rpm",
+        devel = "//third-party/fedora31/kernel:5.3.7-301.fc31.x86_64-devel.rpm",
+    ),
+}


### PR DESCRIPTION
### Goal
The goal of this change is to be closer to creating a default "kernel artifact" (a kernel bundle containing `vmlinuz`, `initrd`, `modules`, `headers`, `devel`) which is used to run a "vmtest". In fact, the only component that is missing from the list above is the `initrd` because it is more tightly coupled with fb-internal logic. 

### Changes
Similar to how the `busybox` rpm is made available, I have added a few buck targets for `kernel-{core,header,devel}` rpms which are part of the Fedora 31 repository. These are then used to create/extract `modules` and `vmlinuz`.

### Test Plan
```
➜  kernel git:(fedora31-kernel-rpms) ✗ buck clean && buck fetch //third-party/fedora31/kernel/...Starting new Buck daemon...
Parsing buck files: finished in 4.2 sec
Building: finished in 21.4 sec (100%) 3/3 jobs, 3 updated
  Total time: 26.1 sec

➜  kernel git:(fedora31-kernel-rpms) ✗ buck build //third-party/fedora31/kernel/...
69800 blocks
Parsing buck files: finished in 1.9 sec
Building: finished in 17.3 sec (100%) 6/6 jobs, 3 updated
  Total time: 19.3 sec
```

### Next Step
The next step will be an fb-internal change which will move much of what is in `kernel/vm`, including the `initrd` build macro ,into fs_image. In doing so, we can then use to macro in fs_image to completely constuct our "kernel artifact" from scratch in OSS.