### PR TITLE
Helper Method to Normalize Dictionaries

### DIFF
--- a/fs_image/bzl/oss_shim_impl.bzl
+++ b/fs_image/bzl/oss_shim_impl.bzl
@@ -27,6 +27,19 @@ def _invert_dict(d):
     else:
         return d
 
+def _normalize_dict(d):
+    """ Exclude any resources that have `.facebook` in the path as these
+    are internal and require internal FB infra.
+
+    This should be used before `_invert_dict()`
+    """
+    if d and types.is_dict(d):
+        _normalized_dict_keys = _normalize_deps(d.keys())
+
+        return {key: d[key] for key in _normalized_dict_keys}
+    else:
+        return d
+
 def _kernel_artifact_version(version):
     """ Resolve a kernel version to its corresponding kernel artifact.
     Currently, the only `kernel_artifact` available is in
@@ -148,7 +161,7 @@ def _python_library(
     python_library(
         name = name,
         deps = _normalize_deps(deps),
-        resources = _invert_dict(resources),
+        resources = _invert_dict(_normalize_dict(resources)),
         srcs = _invert_dict(srcs),
         visibility = _normalize_visibility(visibility, name),
         **kwargs
@@ -165,7 +178,7 @@ def _python_unittest(
         deps = _normalize_deps(deps),
         labels = tags if tags else [],
         package_style = _normalize_pkg_style(par_style),
-        resources = _invert_dict(resources),
+        resources = _invert_dict(_normalize_dict(resources)),
         **kwargs
     )
 


### PR DESCRIPTION
### Goal
After a discussion with Vinnie, it turns out that we only need the list of BIOSes for FB-specific reasons. In the OSS installation, these BIOSes should be present with the installation of QEMU. As such, it would be nice if we could move the BIOSes to a `/facebook` gated directory. The `qemu_bioses` are being loaded as a `resource` and it seems like `/facebook` normalization only occurs for `deps` atm.

### Changes
- Added a helper method which normalizes the keys of a dictionary (in other words, removes any key-value pair where the key contains `/facebook`)
- Modify `python_unittest` and `python_library` to use this helper function for `resources`

### Test Plan
- First and most importantly, test building `python_library` and `python_unittest` targets that specify the  `resources` kwarg. Make sure that still works
- To test that this actually strips resources that contain `/facebook` directory, we can add a test resource to any of the `python_{library, unittest}` tested in the point above. For example adding `"//fs_image/facebook/vm:asdf": "test_resource"`. We can observe that without this change (in this PR), whatever this resource is added will should fail as buck will fail to evaluate the target. With this change, the build will succeed.