### PR TITLE
Execute rpmbuild + rpmsign inside of the BA for testing repo snapshots.

### DIFF
--- a/fs_image/rpm/BUCK
+++ b/fs_image/rpm/BUCK
@@ -90,6 +90,8 @@ python_library(
     deps = [
         "//fs_image:find_built_subvol",
         "//fs_image:fs_utils",
+        "//fs_image/compiler/items:common",
+        "//fs_image/nspawn_in_subvol:non_booted",
         third_party.library(
             "python-gnupg",
             platform = "python",


### PR DESCRIPTION
Summary:
Without this change the `rpmbuild` and `rpmsign` calls when building a test repo snapshot would use the binaries *inside* the BA, but any shared libs from *outside* the BA (host system).  This causes a problem becaue it's not gauranteed that the host and BA are compatible.  And in fact, on a fedora31 host system + a `centos8` BA this breaks like this:

```
stderr: /home/ls/work/fs_image/buck-image-out/volume/targets/build_appliance:JQj6kDU.0YA.y-bn/volume/usr/bin/rpmbuild: error while loading shared libraries: librpmbuild.so.8: cannot open shared object file: No such file or directory
```

Differential Revision: D21796671

