### PR TITLE
Use `http_file` instead of `remote_file` for third-party libraries

### DIFF
--- a/third-party/fedora31/busybox/BUCK
+++ b/third-party/fedora31/busybox/BUCK
@@ -1,8 +1,9 @@
-remote_file(
+http_file(
     name = "busybox-download",
-    url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/b/busybox-1.30.1-2.fc31.x86_64.rpm",
-    sha1 = "68e3cf78e6e0ced54b657bc5a56afd4ce901494a",
-    out = "busybox-1.30.1-2.fc31.x86_64.rpm",
+    urls = [
+        "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/b/busybox-1.30.1-2.fc31.x86_64.rpm",
+    ],
+    sha256 = "6450a95ecf5948a92a701e604cc9c067442f2f66815488b79a0097f2d3e66717",
 )
 
 genrule(

--- a/third-party/fedora31/kernel/BUCK
+++ b/third-party/fedora31/kernel/BUCK
@@ -1,22 +1,25 @@
-remote_file(
+http_file(
     name = "5.3.7-301.fc31.x86_64-core.rpm",
-    url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-core-5.3.7-301.fc31.x86_64.rpm",
-    sha1 = "dae4263b23930c4f25a7eae28a1fda606abfd561",
-    out = "5.3.7-301.fc31.x86_64-core.rpm",
+    urls = [
+        "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-core-5.3.7-301.fc31.x86_64.rpm",
+    ],
+    sha256 = "f0509e333636e5c34726c8a2b8260bf88fe0a35b95cae6dda62191fee1be4c6a",
 )
 
-remote_file(
+http_file(
     name = "5.3.6-300.fc31.x86_64-headers.rpm",
-    url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-headers-5.3.6-300.fc31.x86_64.rpm",
-    sha1 = "7fe40f1592bb8ac3c47d3f97b447a7bf6f2e0a05",
-    out = "5.3.6-300.fc31.x86_64-headers.rpm",
+    urls = [
+        "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-headers-5.3.6-300.fc31.x86_64.rpm",
+    ],
+    sha256 = "d31acb5e7a91e55c0cea895d2c18da63d29b8e6452ed78b597c5e29c9f83f8fa",
 )
 
-remote_file(
+http_file(
     name = "5.3.7-301.fc31.x86_64-devel.rpm",
-    url = "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-devel-5.3.7-301.fc31.x86_64.rpm",
-    sha1 = "ff5bebf0be74228591bc046175815a3e5ce927f2",
-    out = "5.3.7-301.fc31.x86_64-devel.rpm",
+    urls = [
+        "http://mirrors.kernel.org/fedora/releases/31/Everything/x86_64/os/Packages/k/kernel-devel-5.3.7-301.fc31.x86_64.rpm",
+    ],
+    sha256 = "733aa63b13d26af5bb0596cbeec342a6c9c199bb8348948613e84e976b5d0aa2",
 )
 
 genrule(

--- a/third-party/python/certifi/BUCK
+++ b/third-party/python/certifi/BUCK
@@ -1,8 +1,9 @@
-remote_file(
+http_file(
     name = "certifi-download",
-    url = "https://files.pythonhosted.org/packages/18/b0/8146a4f8dd402f60744fa380bc73ca47303cccf8b9190fd16a827281eac2/certifi-2019.9.11-py2.py3-none-any.whl",
-    sha1 = "7df478a63c2ca0f994f5626c1bfb47ae9fd525e5",
-    out = "certifi-2019.9.11-py2.py3-none-any.whl",
+    urls = [
+        "https://files.pythonhosted.org/packages/57/2b/26e37a4b034800c960a00c4e1b3d9ca5d7014e983e6e729e33ea2f36426c/certifi-2020.4.5.1-py2.py3-none-any.whl",
+    ],
+    sha256 = "1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
 )
 
 prebuilt_python_library(

--- a/third-party/python/chardet/BUCK
+++ b/third-party/python/chardet/BUCK
@@ -1,8 +1,9 @@
-remote_file(
+http_file(
     name = "chardet-download",
-    url = "https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl",
-    sha1 = "96faab7de7e9a71b37f22adb64daf2898e967e3e",
-    out = "chardet-3.0.4-py2.py3-none-any.whl",
+    urls = [
+        "https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl",
+    ],
+    sha256 = "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
 )
 
 prebuilt_python_library(

--- a/third-party/python/click/BUCK
+++ b/third-party/python/click/BUCK
@@ -1,8 +1,9 @@
-remote_file(
+http_file(
     name = "click-download",
-    url = "https://files.pythonhosted.org/packages/fa/37/45185cb5abbc30d7257104c434fe0b07e5a195a6847506c074527aa599ec/Click-7.0-py2.py3-none-any.whl",
-    sha1 = "c5b8267a60ed6a4035eaa575485c2d11d3cf5688",
-    out = "Click-7.0-py2.py3-none-any.whl",
+    urls = [
+        "https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl",
+    ],
+    sha256 = "dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc",
 )
 
 prebuilt_python_library(

--- a/third-party/python/idna/BUCK
+++ b/third-party/python/idna/BUCK
@@ -1,8 +1,9 @@
-remote_file(
+http_file(
     name = "idna-download",
-    url = "https://files.pythonhosted.org/packages/14/2c/cd551d81dbe15200be1cf41cd03869a46fe7226e7450af7a6545bfc474c9/idna-2.8-py2.py3-none-any.whl",
-    sha1 = "428950b762f04cb88c215188c4b60b2d8def8ecd",
-    out = "idna-2.8-py2.py3-none-any.whl",
+    urls = [
+        "https://files.pythonhosted.org/packages/89/e3/afebe61c546d18fb1709a61bee788254b40e736cff7271c7de5de2dc4128/idna-2.9-py2.py3-none-any.whl",
+    ],
+    sha256 = "a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa",
 )
 
 prebuilt_python_library(

--- a/third-party/python/requests/BUCK
+++ b/third-party/python/requests/BUCK
@@ -1,8 +1,9 @@
-remote_file(
+http_file(
     name = "requests-download",
-    url = "https://files.pythonhosted.org/packages/51/bd/23c926cd341ea6b7dd0b2a00aba99ae0f828be89d72b2190f27c11d4b7fb/requests-2.22.0-py2.py3-none-any.whl",
-    sha1 = "e1fc28120002395fe1f2da9aacea4e15a449d9ee",
-    out = "requests-2.22.0-py2.py3-none-any.whl",
+    urls = [
+        "https://files.pythonhosted.org/packages/1a/70/1935c770cb3be6e3a8b78ced23d7e0f3b187f5cbfab4749523ed65d7c9b1/requests-2.23.0-py2.py3-none-any.whl",
+    ],
+    sha256 = "43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
 )
 
 prebuilt_python_library(

--- a/third-party/python/urllib3/BUCK
+++ b/third-party/python/urllib3/BUCK
@@ -1,8 +1,9 @@
-remote_file(
+http_file(
     name = "urllib3-download",
-    url = "https://files.pythonhosted.org/packages/b4/40/a9837291310ee1ccc242ceb6ebfd9eb21539649f193a7c8c86ba15b98539/urllib3-1.25.7-py2.py3-none-any.whl",
-    sha1 = "54cb39b7b05ba73a8a5580e822518afffe864ef5",
-    out = "urllib3-1.25.7-py2.py3-none-any.whl",
+    urls = [
+        "https://files.pythonhosted.org/packages/e1/e5/df302e8017440f111c11cc41a6b432838672f5a70aa29227bf58149dc72f/urllib3-1.25.9-py2.py3-none-any.whl",
+    ],
+    sha256 = "88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115",
 )
 
 prebuilt_python_library(


### PR DESCRIPTION
Use `http_file` instead of `remote_file`.  Mostly this is because it supports `sha256` instead of just `sha1`.  I consider this to be more house keeping than anything.