### PR TITLE
Add python-gnupg third-party dependency

### DIFF
--- a/third-party/python/python-gnupg/BUCK
+++ b/third-party/python/python-gnupg/BUCK
@@ -1,0 +1,13 @@
+http_file(
+    name = "python-gnupg-download",
+    urls = [
+        "https://files.pythonhosted.org/packages/cb/85/8a1588a04172e0853352ecfe214264c65a62ab35374d9ad9c569cf94c2a3/python_gnupg-0.4.6-py2.py3-none-any.whl",
+    ],
+    sha256 = "cba3566e8a8fb7bb417d6897a6e17bfc7f9371052e57eb0057783c07d762a679",
+)
+
+prebuilt_python_library(
+    name = "python-gnupg",
+    binary_src = ":python-gnupg-download",
+    visibility = ["PUBLIC"],
+)


### PR DESCRIPTION
This dependency has been added recently for the purpose of signing rpms.  Let's add the dependency in the OSS repo.

Tests:
Build the target and show the output:
```
]# buck build --show-output //third-party/python/python-gnupg:python-gnupg 
Not using buckd because watchman isn't installed.
Parsing buck files: finished in 0.7 sec
Building... 0.3 sec (0%) 0/2 jobs, 0 updated
 - IDLE
//third-party/python/python-gnupg:python-gnupg buck-out/gen/third-party/python/python-gnupg/__python-gnupg__extracted
```

Visually inspect the output:
```
]# ls -l ~/work/fs_image/buck-out/gen/third-party/python/python-gnupg/__python-gnupg__extracted 
total 68
-rw-rw-r--. 1 ls ls 61772 Apr 17 08:35 gnupg.py
drwxrwxr-x. 2 ls ls  4096 Jun  3 21:53 python_gnupg-0.4.6.dist-info
```